### PR TITLE
Make the config file option accessible by function parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,16 @@ Both configuration files below yield the same output:
   * _Raw password:_ [nsconfig.json](./example/nsconfig-simple.json)
   * _Hash password:_ [nsconfig.json](./example/nsconfig-hash.json)
 
-	var params = nsconfig()
-
+```
+var params = nsconfig()
+```
+yields
 ```json
 {
 	"email": "email@suiteplus.com",
 	"password": "*****",
 	"account": "DDAA12321",
-	"realm": "system.netsuite.com",
+	"realm": "netsuite.com",
 	"role": 3
 }
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ Reads configuration parameters from the following sources (overriding each param
 
   *  Environment variables found with the syntax `NSCONF_<UPPERCASE_PARAMETER_NAME>`. E.g. the `email` param can be forced to something else by exporting `NSCONF_EMAIL=email@example.com`.
 
-The name `nsconfig.json` mentioned above can be overridden by setting the environment variable `NSCONF` with the config file you want to point to. E.g. `NSCONF='nsconfig-myproject.json'` looks for `nsconfig-myproject.json` instead of `nsconfig.json`, using the same methods as mentioned above. This can be useful when working with multiple NetSuite accounts. Please note that this overrides the file name and not the file path.
+When working with multiple netsuite environments you may override the file
+name `nsconfig.json` with e.g. `nsconfig-myproject.json` by either:
+
+  - setting the `conffile` parameter;
+
+  - setting the environment variable `NSCONF` or `NSCONF_CONFFILE`.
+
 
 __projectParams__
 

--- a/dist/default-params.js
+++ b/dist/default-params.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = [{ name: 'email', required: true }, { name: 'password', required: true, base64: true }, { name: 'account', required: true }, { name: 'realm', def: 'netsuite.com' }, { name: 'role' }]; //ps: default is reserved word
+module.exports = [{ name: 'email', required: true }, { name: 'password', required: true, base64: true }, { name: 'account', required: true }, { name: 'realm', def: 'netsuite.com' }, { name: 'role' }, { name: 'conffile', required: false }]; //ps: default is reserved word

--- a/dist/nsconfig.js
+++ b/dist/nsconfig.js
@@ -5,8 +5,7 @@ var _ = {
 },
     osenv = require('osenv');
 
-var nsconfName = require('./nsconf-name'),
-    parseConfig = require('./parse-config'),
+var parseConfig = require('./parse-config'),
     resolveEnv = require('./resolve-env'),
     resolveLocal = require('./resolve-local'),
     checkParams = require('./check-params');
@@ -25,8 +24,10 @@ module.exports = function (params, arg2, arg3) {
         custom = arg2 || {};
     }
 
-    var confFileGlobal = parseConfig(osenv.home() + '/.ns/' + nsconfName),
-        confFileLocal = parseConfig(resolveLocal()),
+    var confFileName = params.conffile || process.env.NSCONF || process.env.NSCONF_CONFFILE || 'nsconfig.json';
+
+    var confFileGlobal = parseConfig(osenv.home() + '/.ns/' + confFileName),
+        confFileLocal = parseConfig(resolveLocal(confFileName)),
         confEnvVars = resolveEnv();
 
     params = _.extend({}, confFileGlobal, confFileLocal, params, confEnvVars);

--- a/dist/resolve-local.js
+++ b/dist/resolve-local.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var nsconfName = require('./nsconf-name'),
-    fs = require('fs'),
+var fs = require('fs'),
     path = require('path');
 
-module.exports = function () {
+module.exports = function resolveLocal(fileName) {
     function parent(pathstr) {
         var out = '';
         var pathobj = path.parse(pathstr);
@@ -14,7 +13,7 @@ module.exports = function () {
         }return out + pathobj.base;
     }
 
-    var pathobj = path.parse(process.cwd() + '/' + nsconfName);
+    var pathobj = path.parse(process.cwd() + '/' + fileName);
     var trial = pathobj.dir + '/' + pathobj.base;
     for (var it = 0; it < 5; it++) {
         if (fs.existsSync(trial)) {

--- a/src/default-params.js
+++ b/src/default-params.js
@@ -5,6 +5,7 @@ module.exports = [
     {name: 'password', required: true, base64: true},
     {name: 'account', required: true},
     {name: 'realm', def: 'netsuite.com'},
-    {name: 'role'}
+    {name: 'role'} ,
+    {name: 'conffile', required : false}
 ]; //ps: default is reserved word
 

--- a/src/nsconf-name.js
+++ b/src/nsconf-name.js
@@ -1,1 +1,0 @@
-module.exports = process.env.NSCONF || 'nsconfig.json';

--- a/src/nsconfig.js
+++ b/src/nsconfig.js
@@ -4,8 +4,7 @@ var _ = {
     },
     osenv = require('osenv');
 
-var nsconfName = require('./nsconf-name'),
-    parseConfig = require('./parse-config'),
+var parseConfig = require('./parse-config'),
     resolveEnv = require('./resolve-env'),
     resolveLocal = require('./resolve-local'),
     checkParams = require('./check-params');
@@ -24,8 +23,10 @@ module.exports = function (params, arg2 , arg3) {
         custom = arg2 || {};
     }
 
-    var confFileGlobal = parseConfig(`${osenv.home()}/.ns/${nsconfName}`),
-        confFileLocal = parseConfig(resolveLocal()),
+    var confFileName = params.conffile || process.env.NSCONF || process.env.NSCONF_CONFFILE || 'nsconfig.json';
+
+    var confFileGlobal = parseConfig(`${osenv.home()}/.ns/${confFileName}`),
+        confFileLocal = parseConfig(resolveLocal(confFileName)),
         confEnvVars = resolveEnv();
 
     params = _.extend({}, confFileGlobal, confFileLocal, params, confEnvVars);

--- a/src/resolve-local.js
+++ b/src/resolve-local.js
@@ -1,9 +1,8 @@
 'use strict';
-var nsconfName = require('./nsconf-name'),
-    fs = require('fs'),
+var fs = require('fs'),
     path = require('path');
 
-module.exports = function () {
+module.exports = function resolveLocal(fileName) {
     function parent(pathstr) {
         var out = '';
         var pathobj = path.parse(pathstr);
@@ -13,7 +12,7 @@ module.exports = function () {
         return out + pathobj.base;
     }
 
-    var pathobj = path.parse(process.cwd() + '/' + nsconfName);
+    var pathobj = path.parse(process.cwd() + '/' + fileName);
     var trial = pathobj.dir + '/' + pathobj.base;
     for (var it = 0; it < 5; it++) {
         if (fs.existsSync(trial)) {


### PR DESCRIPTION
Turn the config file choice into a parameter (`conffile`), so it can be also set without externally changing a global (`process.env`).

Keep the `NSCONF` env var choice for compatibility.
