### PR TITLE
fix travis on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - '5'
 os:
   - 'linux'
-  #- 'osx'
+  - 'osx'
 
 install:
   # - npm config set registry http://23.251.144.68
@@ -20,4 +20,4 @@ after_script:
   - 'npm run coveralls'
 
 script:
-  - 'gulp test'
+  - 'npm test'


### PR DESCRIPTION
No idea why it worked on Linux, it shouldn't have since `gulp` is not installed globally...
